### PR TITLE
Set rp_filter for an attached network interface

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // Version defines current version
-var Version = "0.0.4+git"
+var Version = "0.1.0+git"


### PR DESCRIPTION
For a machine with two network interface from the same network to work, the
kernel needs to accept packets that have different outgoing and incoming
routes.

This change ensures that rp_filter is set on the correct network interface.